### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,11 @@ project(SlicerAIGT)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/SlicerIGT/aigt")
 set(EXTENSION_CATEGORY "IGT")
-set(EXTENSION_CONTRIBUTORS "Tamas Ungi (Queen's University), Rebecca Hisey (Queen's University), Kyle Sunderland (Queen's University)")
+set(EXTENSION_CONTRIBUTORS "Tamas Ungi (PerkLab, Queen's University), Rebbecca Hisey (PerkLab, Queen's University), Andras Lasso (PerkLab, Queen's University), Kyle Sunderland (PerkLab, Queen's University)")
 set(EXTENSION_DESCRIPTION "This extension contains modules to assist in deep learning for guided medical interventions. Included modules can collect data, train networks, and deploy models for real-time image classification." )
 set(EXTENSION_ICONURL "https://github.com/SlicerIGT/aigt/raw/master/SlicerAIGTLogo.png" )
 set(EXTENSION_SCREENSHOTURLS "https://github.com/SlicerIGT/aigt/raw/master/Screenshots/UltrasoundSegmentation.png" )
+set(EXTENSION_DEPENDS "SlicerOpenIGTLink SlicerIGT")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.